### PR TITLE
Add fix for Chef 13 warning

### DIFF
--- a/lib/chef-sudo.rb
+++ b/lib/chef-sudo.rb
@@ -64,6 +64,8 @@ end
 class Chef
   class Provider
     class Sudo < Chef::Provider
+      provides :sudo
+      
       def load_current_resource
       end
 


### PR DESCRIPTION
This commit fixes a warning when running Chef 12.x:

WARN: Class Chef::Provider::Sudo does not declare 'provides :sudo'.
WARN: This will no longer work in Chef 13: you must use 'provides' to use the resource's DSL.